### PR TITLE
Fix memory leak

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,6 +55,7 @@ module.exports = (callback, options) => {
       debugLog('stack', cached.stack)
       dispatchCallback(dt, cleanStack(cached.stack))
     }
+    cache.delete(asyncId)
   }
 
   asyncHook.enable()


### PR DESCRIPTION
This should address #7 .

You can reproduce it with the following code.
```
const humanSize = require('human-size');
const blocked = require('./blocked-at');

blocked(() => {});

function main() {
  const { heapUsed } = process.memoryUsage();
  console.log(humanSize(heapUsed, 2));
  setTimeout(main, 0);
}

main();
```