### PR TITLE
asyncHook.disable was pointing to the wrong object

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,7 +65,9 @@ module.exports = (callback, options) => {
 
   asyncHook.enable()
   return {
-    stop: asyncHook.disable
+    stop: () => {
+      asyncHook.disable();
+    }
   }
 }
 


### PR DESCRIPTION
asyncHook should point to the asyncHook object, not the object created by blocked-at