### PR TITLE
add option to expose resource details

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,14 +42,29 @@ const { stop } = blocked(fn, options)
 |`trimFalsePositives`|*falsy*| eliminate a class of false positives (experimental) |
 |`threshold`| *20* | minimum miliseconds of blockage to report. supported for parity with [`blocked`](https://www.npmjs.com/package/blocked)|
 |`debug`| *falsy* | print debug data to console |
+|`exposeResourceDetails`|*falsy*| provides `{type, resource}` taken from async hook as third callback argument (experimental) |
 
 Returns: An object with `stop` method. `stop()` will disable the async hooks set up by this library and callback will no longer be called.
 
-## Using the stack trace
+## Using the stack trace and resource details
 
 The stack trace is pointing to a start of a function called asynchronously, so in most cases the first stack frame pointing to your code is where you need to start analyzing all synchronous operations to find the slow one.
 
-In some cases your code is not directly called and tracking it down will still be difficult. See how the http test case produces a stack pointing to `Server.connectionListener` as the slow function, because everything inside of it is synchronously called. You can always wrap your handlers' code in `setImmediate` if you become desperate.
+In some cases your code is not directly called and tracking it down will still be difficult. See how the http test case produces a stack pointing to `Server.connectionListener` as the slow function, because everything inside of it is synchronously called. You can try to narrow down your search by using `exposeResourceDetails` option and inspecting an associated [resource](https://nodejs.org/api/async_hooks.html#async_hooks_resource):
+
+```js
+blocked((time, stack, {type, resource}) => {
+  console.log(`Blocked for ${time}ms, operation started here:`, stack)
+  if (type === 'HTTPPARSER') {
+    console.log(`URL related to blocking operation: ${resource.incoming.url}`)
+  }
+})
+```
+
+After you've identified a problematic URL, you can wrap your handlers' code in `setImmediate` which should make the stack point to something meaningful.
+
+**Warning**: Exposing resource details has a significant memory overhead, to the point of crashing the entire application due to exceeding heap limit. Use it with care and definitely not in production.
+
 
 # License
 

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "node ./test/index.js && node ./test/runtime.js",
+    "test:rd": "node ./test/resource-details.js",
     "start": "standard --fix"
   },
   "repository": {

--- a/test/cases/http.js
+++ b/test/cases/http.js
@@ -10,7 +10,7 @@ module.exports = function start () {
 
   server.listen(0, 'localhost', function () {
     const addr = server.address()
-    http.get(`http://${addr.address}:${addr.port}`, function (res) {
+    http.get(`http://${addr.address}:${addr.port}/some-url`, function (res) {
       res.resume()
       res.once('end', server.close.bind(server))
     })

--- a/test/resource-details.js
+++ b/test/resource-details.js
@@ -1,0 +1,9 @@
+'use strict'
+const blocked = require('../')
+const http = require('./cases/http')
+
+blocked((time, stack, {type, resource}) => {
+  console.log(time, stack, type, resource.incoming.url)
+}, {exposeResourceDetails: true})
+
+setImmediate(http)


### PR DESCRIPTION
Hello,

I was trying to decipher stack traces pointing to server listeners and I thought that having an async resource associated with blocking operation might provide some context. Wrapping each route with `setImmediate`s in an app with dozens of routes seemed dreadful, especially since it messes with async/await error handling.

So, exposing a resource works and can be useful, but it comes with some caveats:
- I've changed `dispatchCallback` to direct call because I wanted to avoid the situation where the resource was supposed to be released before it reaches the callback
- I've added a warning against using it carelessly because when I tested my app with a heavy load it kept on crashing when the resource was being exposed. This one still puzzles me - I'd assume that resource is only the reference to an object that exists anyway during the lifetime of an async operation. That doesn't seem to be true, as ignoring it in `init` prevents the app from crashing. I'm really curious what your thoughts on that are.

Cheers!
